### PR TITLE
Lazy-fetch images on quiz result cards

### DIFF
--- a/src/components/quiz/results/MatchImage.tsx
+++ b/src/components/quiz/results/MatchImage.tsx
@@ -1,0 +1,40 @@
+import { useBreedImage } from "@/hooks/useBreeds";
+
+interface MatchImageProps {
+  name: string;
+  imageUrl?: string;
+  referenceImageId?: string;
+  className?: string;
+  emojiSize?: string;
+}
+
+export function MatchImage({
+  name,
+  imageUrl,
+  referenceImageId,
+  className = "w-full h-full object-cover",
+  emojiSize = "text-4xl",
+}: MatchImageProps) {
+  const shouldFetch = !imageUrl && !!referenceImageId;
+  const { data: lazyImage } = useBreedImage(referenceImageId, shouldFetch);
+
+  const resolvedUrl = imageUrl ?? lazyImage?.url;
+
+  if (!resolvedUrl) {
+    return (
+      <div className="w-full h-full flex items-center justify-center bg-amber-100">
+        <span className={`text-amber-500 ${emojiSize}`}>🐱</span>
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={resolvedUrl}
+      alt={name}
+      loading="lazy"
+      decoding="async"
+      className={className}
+    />
+  );
+}

--- a/src/components/quiz/results/OtherMatches.tsx
+++ b/src/components/quiz/results/OtherMatches.tsx
@@ -3,6 +3,7 @@ import { ExternalLink } from "lucide-react";
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { BreedMatch } from "@/types/quiz";
+import { MatchImage } from "./MatchImage";
 
 interface OtherMatchesProps {
   matches: BreedMatch[];
@@ -23,17 +24,12 @@ export function OtherMatches({ matches, onClose }: OtherMatchesProps) {
           <div className="flex justify-between items-start">
             <div className="flex gap-3 items-center">
               <div className="w-12 h-12 rounded-md overflow-hidden bg-amber-100 flex-shrink-0">
-                {match.imageUrl ? (
-                  <img 
-                    src={match.imageUrl} 
-                    alt={match.name} 
-                    className="w-full h-full object-cover"
-                  />
-                ) : (
-                  <div className="w-full h-full flex items-center justify-center">
-                    <span className="text-amber-500 text-2xl">🐱</span>
-                  </div>
-                )}
+                <MatchImage
+                  name={match.name}
+                  imageUrl={match.imageUrl}
+                  referenceImageId={match.referenceImageId}
+                  emojiSize="text-2xl"
+                />
               </div>
               
               <div>

--- a/src/components/quiz/results/PrimaryMatch.tsx
+++ b/src/components/quiz/results/PrimaryMatch.tsx
@@ -4,6 +4,7 @@ import { ExternalLink } from "lucide-react";
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { BreedMatch } from "@/types/quiz";
+import { MatchImage } from "./MatchImage";
 
 interface PrimaryMatchProps {
   match: BreedMatch;
@@ -25,17 +26,11 @@ export function PrimaryMatch({ match, onClose }: PrimaryMatchProps) {
       
       <div className="flex flex-col sm:flex-row gap-4 items-center sm:items-start">
         <div className="w-24 h-24 sm:w-32 sm:h-32 rounded-lg overflow-hidden bg-amber-100 flex-shrink-0">
-          {match.imageUrl ? (
-            <img 
-              src={match.imageUrl} 
-              alt={match.name} 
-              className="w-full h-full object-cover"
-            />
-          ) : (
-            <div className="w-full h-full flex items-center justify-center bg-amber-100">
-              <span className="text-amber-500 text-4xl">🐱</span>
-            </div>
-          )}
+          <MatchImage
+            name={match.name}
+            imageUrl={match.imageUrl}
+            referenceImageId={match.referenceImageId}
+          />
         </div>
         
         <div className="flex-1 text-center sm:text-left">

--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -41,6 +41,7 @@ export interface BreedMatch {
   name: string;
   matchPercentage: number;
   imageUrl?: string;
+  referenceImageId?: string;
   description: string;
   matchReasons: string[];
 }

--- a/src/utils/quiz-matching.ts
+++ b/src/utils/quiz-matching.ts
@@ -211,6 +211,7 @@ export function calculateBreedMatches(answers: QuizAnswer[], breeds: Breed[]): B
       name: breed.name,
       matchPercentage: matchPercentage,
       imageUrl: breed.image?.url,
+      referenceImageId: breed.reference_image_id,
       description: breed.description || `A ${breed.name} cat that matches your lifestyle preferences.`,
       matchReasons: matchReasons.slice(0, 3) // Limit to top 3 reasons
     };


### PR DESCRIPTION
## Summary
- Follow-up to #15. After switching `fetchBreeds` to skip the per-breed image waterfall, breeds that previously had images resolved via `reference_image_id` came through with `image` undefined. The quiz result cards only read `breed.image?.url`, so those matches fell back to the generic cat emoji.
- Carries `reference_image_id` through to `BreedMatch`, adds a small `MatchImage` component that reuses the existing `useBreedImage` hook to lazy-fetch when the URL is missing, and uses it in both `PrimaryMatch` and `OtherMatches`.

## Test plan
- [ ] Take the quiz and verify the primary match card shows a real breed photo instead of the 🐱 placeholder.
- [ ] Verify other-match cards also show real photos.
- [ ] Confirm the breed grid on the home page still renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)